### PR TITLE
[Tooling] Setup for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/arduino.json

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,25 @@
+{
+    "configurations": [
+        {
+            "name": "Arduino",
+            "includePath": [
+                "${config:arduino.path}/hardware/arduino/avr/cores/arduino/**",
+                "${config:arduino.path}/tools/**",
+                "${config:arduino.path}/hardware/tools/**",
+                "${config:arduino.path}/hardware/arduino/avr/**",
+                "${config:arduino.path}/libraries/**",
+                "${HOME}/Arduino/libraries/**",
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "USBCON",
+                "ARDUINO=10800"
+            ],
+            "compilerPath": "${config:arduino.path}/hardware/tools/avr/bin/avr-gcc",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
This PR adds the necessary config for an Arduino project to work with the `vscode-arduino` plugin when it's properly configured (i.e., `arduino.path` and `arduino.commandPath` are set in `settings.json`).

### Checklist:

- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [ ] I have compiled this code (n/a)
- [x] I have run this code
- [ ] I have made corresponding changes to the documentation (n/a)
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a)
